### PR TITLE
Update specifity of severity input description

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Following inputs can be used as `step.with` keys
 | `image`              | String | Container image to scan (e.g. `alpine:3.7`)                                                      |
 | `tarball`            | String | Container image tarball path to scan                                                             |
 | `dockerfile`         | String | Dockerfile required to generate a sarif report                                                   |
-| `severity`           | String | Report vulnerabilities of provided level or higher (default: `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`) |
+| `severity`           | String | Report vulnerabilities of provided level(s) (default: `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`) |
 | `severity_threshold` | String | Defines threshold for severity                                                                   |
 | `annotations`        | Bool   | Create GitHub annotations in your workflow for vulnerabilities discovered                        |
 

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: 'Dockerfile required to generate a sarif report'
     required: false
   severity:
-    description: 'Report vulnerabilities of provided level or higher (default: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)'
+    description: 'Report vulnerabilities of provided level(s) (default: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)'
     required: false
   severity_threshold:
     description: 'Defines threshold for severity'


### PR DESCRIPTION
### Motivation
The description for the severity input gives the impression that the input expects a single value that uses a >= operator to determine the severity level of CVEs reported.

The input is actually a list, which is alluded to by the default but no clear from the description text.

### Changes
1. Updates the text to specify that the input expects a list

